### PR TITLE
Update deprecated usage of np.int

### DIFF
--- a/oemer/staffline_extraction.py
+++ b/oemer/staffline_extraction.py
@@ -324,7 +324,7 @@ def extract(splits=8, line_threshold=0.8, horizontal_diff_th=0.1, unit_size_diff
     all_staffs = []
     for rr in zones:
         print(rr[0], rr[-1], end=' ')
-        rr = np.array(rr, dtype=np.int)
+        rr = np.array(rr, dtype=int)
         staffs = extract_part(staff_pred[:, rr], x_offset=rr[0], line_threshold=line_threshold)
         if staffs is not None:
             all_staffs.append(staffs)


### PR DESCRIPTION
Remove deprecated usage of `numpy.int` as it was deprecated in [NumPy 1.20](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) and was removed in [NumPy 1.24](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations)

PR fixes #25 