### PR TITLE
Avoiding artifacts at the border

### DIFF
--- a/oemer/dewarp.py
+++ b/oemer/dewarp.py
@@ -284,7 +284,7 @@ def estimate_coords(staff_pred):
 
 
 def dewarp(img, coords_x, coords_y):
-    return cv2.remap(img.astype(np.float32), coords_x,coords_y, cv2.INTER_CUBIC)
+    return cv2.remap(img.astype(np.float32), coords_x,coords_y, cv2.INTER_CUBIC, borderMode=cv2.BORDER_REPLICATE)
 
 
 if __name__ == "__main__":
@@ -326,7 +326,7 @@ if __name__ == "__main__":
     grid_x, grid_y = np.mgrid[0:gg_map.shape[0]:1, 0:gg_map.shape[1]:1]
     mapping = griddata(points, vals, (grid_x, grid_y), method='linear')
     for i in range(out.shape[-1]):
-        out[..., i] = cv2.remap(out[..., i].astype(np.float32), grid_y.astype(np.float32), mapping.astype(np.float32), cv2.INTER_CUBIC)
+        out[..., i] = cv2.remap(out[..., i].astype(np.float32), grid_y.astype(np.float32), mapping.astype(np.float32), cv2.INTER_CUBIC, borderMode=cv2.BORDER_REPLICATE)
 
     mix = np.hstack([ori_img, out])
 


### PR DESCRIPTION
Hi,

dewarp might introduce black areas at the borders of the image, which in later steps might be interpreted as random symbols. By using border replicate in the remap operation we avoid this issue.

Alternatives: Instead of replicate we could also fill the border areas created by remap with a constant gray color, but overall the replicate option appears to be the simpler approach.