### PR TITLE
Fixed TypeError at start of unet or segnet training

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9']
+        python-version: ["3.9"]
 
     steps:
       - uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
             setup.py
 
@@ -43,4 +43,4 @@ jobs:
       - name: Lint with ruff
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          ruff --format=github --select=E9,F63,F7,F82 --target-version=py37 .
+          ruff --output-format=github --select=E9,F63,F7,F82 --target-version=py37 .

--- a/oemer/train.py
+++ b/oemer/train.py
@@ -376,6 +376,7 @@ class WarmUpLearningRate(tf.keras.optimizers.schedules.LearningRateSchedule):
         self.warm_step_size = (init_lr - min_lr) / warm_up_steps
 
     def __call__(self, step):
+        step = tf.cast(step, tf.float32)
         warm_lr = self.min_lr + self.warm_step_size * step
 
         offset = step - self.warm_up_steps


### PR DESCRIPTION
Fixed 'TypeError: Cannot convert 4.999899999999999e-07 to EagerTensor of dtype int64' in training, fixes #39

The solution was taken from this discussion: https://stackoverflow.com/questions/76511182/tensorflow-custom-learning-rate-scheduler-gives-unexpected-eagertensor-type-erro